### PR TITLE
Add issue identifier and URL to Linear issue information

### DIFF
--- a/src/effects/linear/client.mock.js
+++ b/src/effects/linear/client.mock.js
@@ -22,6 +22,8 @@ export function createMockLinearClient(options = {}) {
   const defaultNodes = [
     {
       id: 'mock-issue-1',
+      identifier: 'MAIN-123',
+      url: 'https://linear.app/scoutos/issue/MAIN-123/mock-issue-1',
       title: 'Mock Issue 1',
       description: 'This is a mock issue for testing',
       priority: 2,
@@ -43,6 +45,8 @@ export function createMockLinearClient(options = {}) {
     },
     {
       id: 'mock-issue-2',
+      identifier: 'MAIN-124',
+      url: 'https://linear.app/scoutos/issue/MAIN-124/mock-issue-2',
       title: 'Mock Issue 2',
       description: 'Another mock issue',
       priority: 1,
@@ -252,6 +256,8 @@ export function createMockLinearClient(options = {}) {
       // Create a mock issue with the input data
       const mockIssue = {
         id: 'mock-created-issue-id',
+        identifier: 'MAIN-999',
+        url: 'https://linear.app/scoutos/issue/MAIN-999/mock-created-issue',
         title: issueInput.title,
         description: issueInput.description || null,
         priority: issueInput.priority !== undefined ? issueInput.priority : 0,

--- a/src/effects/linear/types/types.js
+++ b/src/effects/linear/types/types.js
@@ -54,6 +54,8 @@ export const ProjectSchema = z.object({
  */
 export const IssueSchema = z.object({
   id: z.string(),
+  identifier: z.string().optional(), // The issue identifier (e.g., "TEAM-123")
+  url: z.string().optional(), // The full URL to the issue in Linear
   title: z.string().optional(),
   description: z.string().optional(),
   status: z.string().optional(),

--- a/src/tools/get-issue.js
+++ b/src/tools/get-issue.js
@@ -153,6 +153,8 @@ async function getIssue(
     // Process and validate the issue data
     const processedIssue = IssueSchema.parse({
       id: issue.id,
+      identifier: issue.identifier || undefined, // Add the issue identifier (e.g. TEAM-123)
+      url: issue.url || undefined, // Add the issue URL for linking
       title: issue.title,
       description: issue.description || undefined,
       priority: issue.priority,
@@ -256,6 +258,12 @@ const handler = async (ctx, { issueId, includeComments, debug }) => {
     // Format the issue details
     responseText += `# ${issue.title || 'Untitled'}\n\n`;
     responseText += `**ID:** ${issue.id}\n`;
+    if (issue.identifier) {
+      responseText += `**Identifier:** ${issue.identifier}\n`;
+    }
+    if (issue.url) {
+      responseText += `**URL:** ${issue.url}\n`;
+    }
     responseText += `**Status:** ${issue.status || 'Unknown'}\n`;
     responseText += `**Priority:** ${priorityMap[priority] || 'Unknown'}\n`;
 

--- a/src/tools/get-issue.test.js
+++ b/src/tools/get-issue.test.js
@@ -50,6 +50,8 @@ describe('getIssue', () => {
     assert.ok(result, 'Result should exist');
     assert.strictEqual(result.id, issueId, 'Issue ID should match');
     assert.ok(result.title, 'Issue should have a title');
+    assert.ok(result.identifier, 'Issue should have an identifier');
+    assert.ok(result.url, 'Issue should have a URL');
 
     // Verify the logger recorded the expected logs
     assert.ok(

--- a/src/tools/list-issues.js
+++ b/src/tools/list-issues.js
@@ -212,6 +212,8 @@ async function listIssues(
 
         const processedIssue = IssueSchema.parse({
           id: issue.id,
+          identifier: issue.identifier || undefined, // Add the issue identifier (e.g. TEAM-123)
+          url: issue.url || undefined, // Add the issue URL for linking
           title: issue.title,
           description: issue.description || undefined,
           priority: issue.priority,
@@ -361,6 +363,12 @@ const handler = async (
 
         responseText += `${index + 1}. ${issue.title || 'Untitled'}\n`;
         responseText += `   ID: ${issue.id}\n`;
+        if (issue.identifier) {
+          responseText += `   Identifier: ${issue.identifier}\n`;
+        }
+        if (issue.url) {
+          responseText += `   URL: ${issue.url}\n`;
+        }
         responseText += `   Status: ${issue.status || 'Unknown'}\n`;
         responseText += `   Priority: ${priorityMap[priority] || 'Unknown'}\n`;
 

--- a/src/tools/list-issues.test.js
+++ b/src/tools/list-issues.test.js
@@ -57,6 +57,12 @@ describe('ListIssues Tool', () => {
         result.results.every(issue => issue.status === 'In Progress'),
         'All returned issues should have status "In Progress"'
       );
+      
+      // Check for new fields
+      if (result.results.length > 0) {
+        assert.ok(result.results[0].identifier, 'Issue should have an identifier');
+        assert.ok(result.results[0].url, 'Issue should have a URL');
+      }
     });
 
     it('should correctly filter by assignee name', async () => {

--- a/src/tools/list-issues.test.js
+++ b/src/tools/list-issues.test.js
@@ -57,10 +57,13 @@ describe('ListIssues Tool', () => {
         result.results.every(issue => issue.status === 'In Progress'),
         'All returned issues should have status "In Progress"'
       );
-      
+
       // Check for new fields
       if (result.results.length > 0) {
-        assert.ok(result.results[0].identifier, 'Issue should have an identifier');
+        assert.ok(
+          result.results[0].identifier,
+          'Issue should have an identifier'
+        );
         assert.ok(result.results[0].url, 'Issue should have a URL');
       }
     });


### PR DESCRIPTION
## Summary
- Added identifier and URL fields to the IssueSchema in Linear types
- Updated list-issues and get-issue tools to include these fields in output
- Enhanced mock client for testing with these new fields
- Updated tests to verify the new fields are present

## Test plan
- Ran the existing test suite, which has been updated to check for the new fields
- Manual testing can be done by running the tools and verifying the output includes the new fields